### PR TITLE
[Fixes #9] 

### DIFF
--- a/docs/developer/05-notification-plugins.md
+++ b/docs/developer/05-notification-plugins.md
@@ -111,7 +111,9 @@ The following values may be available after the job is finished (not available f
 
 `execution.context` - this is a map containing all of the context variables available to the execution when it ran or will run, such as [Jobs - Context Variables](/manual/job-workflows.md#context-variables). The contents of this Map are the specific context namespaces and variables.
 
-`execution.context.option`: a Map containing the Job Option keys/values.
+`execution.context.option`: a Map containing all Job Option keys/values.
+
+`execution.context.secureOption`: a Map containing only the Job Option keys/values whose value is set from secure storage.
 
 `job`: a Map containing the Job context data, as provided to executions. This map will contain some duplicate information as the `execution.job` map previously described.
 


### PR DESCRIPTION
This change simply adds a description of `execution.context.secureOption` to the developer docs `NotificationPlugin`'s with distinction from the already-present `execution.context.option`. It is a member of the context passed within the `executionData` map that is provided as input to a `NotificationPlugin` implementation.

In my case, it wasn't possible to view the members of the input object and having this listed within the docs would have saved me some time and may be useful to others.